### PR TITLE
Cutover Gate F: dogfood-lab/testing-os

### DIFF
--- a/bin/shipcheck.mjs
+++ b/bin/shipcheck.mjs
@@ -214,7 +214,7 @@ function auditCommand() {
 
 // --- Gate F: Dogfood freshness ---
 
-const DEFAULT_DOGFOOD_REPO = "mcp-tool-shop-org/dogfood-labs";
+const DEFAULT_DOGFOOD_REPO = "dogfood-lab/testing-os";
 const DEFAULT_DOGFOOD_REF = "main";
 const DEFAULT_FRESHNESS_DAYS = 30;
 
@@ -344,7 +344,7 @@ async function dogfoodCommand() {
   // Fetch index
   const fetchResult = await fetchDogfoodIndex(dogfoodRepo, dogfoodRef);
   if (!fetchResult.ok) {
-    fail(fetchResult.error, fetchResult.detail, "Check that dogfood-labs repo and indexes/latest-by-repo.json exist");
+    fail(fetchResult.error, fetchResult.detail, "Check that dogfood-lab/testing-os repo and indexes/latest-by-repo.json exist");
   }
 
   // Evaluate
@@ -384,7 +384,7 @@ ${BOLD}What it does:${RESET}
            Reports pass rate and lists remaining gaps
            Exits 0 if all gates pass, 1 if gaps remain
 
-  dogfood  Checks dogfood-labs for a fresh, passing record
+  dogfood  Checks dogfood-lab/testing-os for a fresh, passing record
            --repo org/repo       Target repo (required)
            --surface cli|desktop  Product surface (required)
            --freshness-days 30   Max age in days (default: 30)


### PR DESCRIPTION
## Summary
- `DEFAULT_DOGFOOD_REPO` constant flipped from `mcp-tool-shop-org/dogfood-labs` → `dogfood-lab/testing-os`.
- Two cosmetic strings updated (error hint and `--help` text).

## Why
The dogfood evidence store has been migrated into a new monorepo at https://github.com/dogfood-lab/testing-os (Wave 6 of the testing-os migration). The data layout inside the repo is unchanged — `indexes/latest-by-repo.json` and `policies/repos/<repo>.yaml` are still there at the same paths — so Gate F's fetch logic does not change.

Operators can still override with `--dogfood-repo` if they want to point at the legacy archive during the cutover window.

## Test plan
- [ ] CI passes
- [ ] `npx @mcptoolshop/shipcheck audit --gate F --repo mcp-tool-shop-org/world-forge --surface cli` succeeds against the new repo
- [ ] Existing `--dogfood-repo` override still works (covered by existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)