### PR TITLE
Cutover residual dogfood-labs refs to dogfood-lab/testing-os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
           # Build payload with submission as a proper JSON object (not string)
           jq -n --argjson sub "$SUBMISSION" \
             '{"event_type":"dogfood_submission","client_payload":{"submission":$sub}}' \
-            | gh api repos/mcp-tool-shop-org/dogfood-labs/dispatches \
+            | gh api repos/dogfood-lab/testing-os/dispatches \
               --input - --silent
 
-          echo "Dispatched $RUN_ID to dogfood-labs"
+          echo "Dispatched $RUN_ID to testing-os"

--- a/site/src/content/docs/handbook/getting-started.md
+++ b/site/src/content/docs/handbook/getting-started.md
@@ -87,7 +87,7 @@ Exits 0 when all hard gates pass. Exits 1 if gaps remain.
 
 ### 8. Dogfood check (optional)
 
-If your org uses [dogfood-labs](https://github.com/mcp-tool-shop-org/dogfood-labs) for verification, you can also check Gate F:
+If your org uses [testing-os](https://github.com/dogfood-lab/testing-os) for verification, you can also check Gate F:
 
 ```bash
 npx @mcptoolshop/shipcheck dogfood --repo org/repo --surface cli

--- a/site/src/content/docs/handbook/reference.md
+++ b/site/src/content/docs/handbook/reference.md
@@ -37,7 +37,7 @@ Reads `SHIP_GATE.md`, counts checked/unchecked/skipped items, and reports:
 npx @mcptoolshop/shipcheck dogfood --repo org/repo --surface cli
 ```
 
-Checks the dogfood-labs index for a fresh, verified, passing dogfood record. This is Gate F.
+Checks the testing-os index for a fresh, verified, passing dogfood record. This is Gate F.
 
 **Flags:**
 
@@ -46,10 +46,10 @@ Checks the dogfood-labs index for a fresh, verified, passing dogfood record. Thi
 | `--repo` | yes | — | Target repo slug (e.g. `mcp-tool-shop-org/shipcheck`) |
 | `--surface` | yes | — | Product surface (e.g. `cli`, `desktop`) |
 | `--freshness-days` | no | 30 | Maximum age in days for the dogfood record |
-| `--dogfood-repo` | no | `mcp-tool-shop-org/dogfood-labs` | Override the dogfood-labs repo |
-| `--dogfood-ref` | no | `main` | Override the dogfood-labs branch |
+| `--dogfood-repo` | no | `dogfood-lab/testing-os` | Override the dogfood evidence repo |
+| `--dogfood-ref` | no | `main` | Override the dogfood evidence branch |
 
-**Enforcement modes** (set via per-repo policy files in dogfood-labs):
+**Enforcement modes** (set via per-repo policy files in testing-os):
 
 - `required` — Gate F blocks on failure (default)
 - `warn-only` — Prints a warning but exits 0

--- a/test/shipcheck.test.mjs
+++ b/test/shipcheck.test.mjs
@@ -403,7 +403,7 @@ describe("dogfood command (CLI)", () => {
 describe("fetchEnforcementMode", () => {
   it("returns required for a repo with enforcement: required (live)", async () => {
     const result = await fetchEnforcementMode(
-      "mcp-tool-shop-org/dogfood-labs", "main", "mcp-tool-shop-org/shipcheck"
+      "dogfood-lab/testing-os", "main", "mcp-tool-shop-org/shipcheck"
     );
     assert.equal(result.mode, "required");
     assert.equal(result.reason, null);
@@ -412,7 +412,7 @@ describe("fetchEnforcementMode", () => {
 
   it("returns required when policy file does not exist (live)", async () => {
     const result = await fetchEnforcementMode(
-      "mcp-tool-shop-org/dogfood-labs", "main", "mcp-tool-shop-org/nonexistent-repo-xyz"
+      "dogfood-lab/testing-os", "main", "mcp-tool-shop-org/nonexistent-repo-xyz"
     );
     assert.equal(result.mode, "required");
   });


### PR DESCRIPTION
## Summary

Session F audit (against [dogfood-lab/testing-os HANDOFF.md](https://github.com/dogfood-lab/testing-os/blob/main/HANDOFF.md)) found 4 residual references inside this repo that were missed by [PR #2](https://github.com/mcp-tool-shop-org/shipcheck/pull/2).

| File | Line | What |
|------|------|------|
| `.github/workflows/ci.yml` | 202 | Own dogfood dispatch still hit the archived legacy repo |
| `site/src/content/docs/handbook/getting-started.md` | 90 | User-facing link to legacy GitHub URL |
| `site/src/content/docs/handbook/reference.md` | 49 | `--dogfood-repo` default in flag table |
| `test/shipcheck.test.mjs` | 406, 415 | Live integration tests fetching from legacy org policies |

## Test plan

- [x] `npm test` passes locally — 43 tests, 0 fails
- [x] Live `fetchEnforcementMode` test hits `dogfood-lab/testing-os/main/policies/repos/mcp-tool-shop-org/shipcheck.yaml` and gets `enforcement: required` (the policy file was migrated in Wave 5)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)