### PR TITLE
test: revert --freshness-days 9999 workaround

### DIFF
--- a/test/shipcheck.test.mjs
+++ b/test/shipcheck.test.mjs
@@ -379,21 +379,8 @@ describe("dogfood command (CLI)", () => {
   });
 
   it("passes for a known good repo+surface (live)", () => {
-    // NOTE: --freshness-days is bumped high here intentionally. This test
-    // exercises the live fetch+evaluate+render path against dogfood-lab/testing-os
-    // for shipcheck's own record. It must NOT depend on the calendar age of the
-    // last published dogfood run, because:
-    //   1. The dogfood dispatch step in ci.yml skips silently when DOGFOOD_TOKEN
-    //      is unset (warning, exit 0), so the testing-os index can fall behind.
-    //   2. Branches that go >30 days between merge → main (e.g. long-lived
-    //      dependency-bump branches) would otherwise fail this test on a
-    //      pre-existing freshness drift, not on anything they actually changed.
-    // The contract this test still proves: shipcheck's record exists in the
-    // index, has verified:pass + verification_status:accepted, and Gate F
-    // renders the "passed" branch. Freshness logic itself is covered by unit
-    // tests against evaluateDogfoodGate with synthetic dates.
     const { exitCode, stdout } = run(
-      ["dogfood", "--repo", "mcp-tool-shop-org/shipcheck", "--surface", "cli", "--freshness-days", "9999"],
+      ["dogfood", "--repo", "mcp-tool-shop-org/shipcheck", "--surface", "cli"],
       process.cwd()
     );
     assert.equal(exitCode, 0);
@@ -433,12 +420,8 @@ describe("fetchEnforcementMode", () => {
 
 describe("dogfood enforcement CLI", () => {
   it("passes with required mode for a known good repo (live)", () => {
-    // See note on the matching test in "dogfood command" above — --freshness-days
-    // is bumped high to decouple this live test from calendar drift in the
-    // testing-os index. Contract proved: required-mode policy is fetched and
-    // a valid pass record renders Gate F passed.
     const { exitCode, stdout } = run(
-      ["dogfood", "--repo", "mcp-tool-shop-org/shipcheck", "--surface", "cli", "--freshness-days", "9999"],
+      ["dogfood", "--repo", "mcp-tool-shop-org/shipcheck", "--surface", "cli"],
       process.cwd()
     );
     assert.equal(exitCode, 0);


### PR DESCRIPTION
## Summary
- Removes `--freshness-days 9999` from the two live Gate F tests in `test/shipcheck.test.mjs`
- Removes the 14-line NOTE comments explaining why the bump was there
- Restores default 30-day freshness enforcement in tests

## Why the workaround existed
shipcheck CI's dogfood dispatch step had silently no-op'd since the 2026-04-25 org cutover — `DOGFOOD_TOKEN` wasn't rotated until 2026-04-29, and no commits to main happened between those dates. The April 25 run's log shows `##[warning]DOGFOOD_TOKEN not set — skipping dispatch`. As a result, shipcheck's `dogfood-lab/testing-os` record was frozen at `2026-03-26T00:32:46Z`.

The freshness gate then failed live tests on every new branch (61 days old > 30 day limit), which gated the dogfood job that would have refreshed the record. PR #4 patched around this with `--freshness-days 9999`.

## Why it's safe to revert now
[PR #4](https://github.com/mcp-tool-shop-org/shipcheck/pull/4) merged at `2026-05-26T04:26:15Z` → its main CI run ([26432213788](https://github.com/mcp-tool-shop-org/shipcheck/actions/runs/26432213788)) ran the dogfood dispatch successfully → `testing-os` ingest accepted the submission → `indexes/latest-by-repo.json` now has `finished_at: 2026-05-26T04:26:48Z` for `mcp-tool-shop-org/shipcheck`. Verified via API.

## Test plan
- [x] `npm test` locally — all 43 tests pass against the fresh testing-os record
- [ ] CI verify job passes (this PR's check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)