### PR TITLE
chore: verify script runs audit instead of init

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "node --test test/*.test.mjs",
-    "verify": "node bin/shipcheck.mjs help && node bin/shipcheck.mjs init && echo '✓ verify passed'"
+    "verify": "node bin/shipcheck.mjs help && node bin/shipcheck.mjs audit && echo '✓ verify passed'"
   },
   "files": [
     "bin",


### PR DESCRIPTION
## Summary
`npm run verify` previously ran `node bin/shipcheck.mjs init`, which **overwrites the committed `SHIP_GATE.md` and `SCORECARD.md`** with template versions on every CI run. That mutates the working tree without validating anything — the templates clobber whatever real progress is captured in the committed gate file. CI doesn't notice because the workspace is ephemeral, but it's a weird smoke test.

Switching to `audit` makes verify actually verify something:
- Read-only (parses `SHIP_GATE.md`, doesn't write)
- Exits non-zero if any hard gate is unchecked
- Prints `Checked / Unchecked / Skipped / Pass rate` counts

## Safety
`audit` does NOT touch `dogfood-lab/testing-os`. Gate F (the freshness gate) lives in the `dogfood` subcommand. So this can't re-introduce the deadlock that [#5](https://github.com/mcp-tool-shop-org/shipcheck/pull/5) just resolved.

## Test plan
- [x] `npm run verify` locally on this branch: exit 0, "All hard gates pass. Ship it."
- [ ] CI verify check passes

Discovered while cleaning up after the PR #4/#5 testing-os refresh — the uncommitted change was sitting in a working tree from prior exploratory work, looked correct, captured here for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)