### PR TITLE
ci: bump Actions to Node 24 (June 16 deprecation)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,4 +47,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Bumps 1 Node-20 action pin(s) to their latest Node-24 SHA-pinned releases ahead of GitHub's 2026-06-16 forced-Node-24 cutover.

Actions: actions/deploy-pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)