### PR TITLE
feat: Gate G — AI-native front-door verifier (site-theme integration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.0.6] - 2026-06-16
+
+### Added
+- **Gate G — AI-native front door**: `shipcheck front-door` verifies a repo's
+  README / AGENTS.md / llms.txt by consuming the `front-door` verifier shipped in
+  `@mcptoolshop/site-theme` (>=2.0.0). Maps the verifier's risk-ordered scorecard
+  (contradicted > unbacked > stale > bloat > hygiene > style) into a shipcheck
+  dimension, prints a counts-by-severity summary + gate verdict, and exits 1 when
+  the front-door gate fails (`scorecard.gate.pass === false`).
+- `@mcptoolshop/site-theme` as an **optional peer dependency** (a hard dependency
+  would pull astro/vite/sharp — ~280 packages — into this zero-dep CLI). When it is
+  not installed the gate SKIPS gracefully (exit 0) and never crashes the audit.
+- Tests for `summarizeFrontDoor` (scorecard mapping) and `runFrontDoorGate`
+  (pass / fail / skip paths via an injected loader, plus CLI E2E).
+
 ## [1.0.5] - 2026-03-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@
 ## CLI usage
 
 ```bash
-npx @mcptoolshop/shipcheck init       # Copy templates into current repo
-npx @mcptoolshop/shipcheck audit      # Check SHIP_GATE.md progress
-npx @mcptoolshop/shipcheck dogfood    # Check dogfood freshness (Gate F)
-npx @mcptoolshop/shipcheck help       # Show help
-npx @mcptoolshop/shipcheck --version  # Show version
+npx @mcptoolshop/shipcheck init        # Copy templates into current repo
+npx @mcptoolshop/shipcheck audit       # Check SHIP_GATE.md progress
+npx @mcptoolshop/shipcheck dogfood     # Check dogfood freshness (Gate F)
+npx @mcptoolshop/shipcheck front-door  # Verify the AI-native front door (Gate G)
+npx @mcptoolshop/shipcheck help        # Show help
+npx @mcptoolshop/shipcheck --version   # Show version
 ```
 
 Set `SHIPCHECK_JSON=1` to get structured JSON error output instead of coloured text.
@@ -71,6 +72,13 @@ Set `SHIPCHECK_JSON=1` to get structured JSON error output instead of coloured t
 - Checks for a fresh, verified, passing dogfood record
 - Supports enforcement modes: `required`, `warn-only`, `exempt`
 - Configurable freshness window (default: 30 days)
+
+**Gate G — AI-native front door** (optional, requires `@mcptoolshop/site-theme` >=2.0.0):
+
+- Verifies that the repo's AI-native front door (README / AGENTS.md / llms.txt) tells the truth — the machine-readable complement to the Operator Docs (C) and Identity (E) gates
+- Delegates to site-theme's [`front-door`](https://github.com/mcp-tool-shop-org/site-theme) verifier (`verify({ root })`), which routes documented claims to evidence channels and returns a risk-ordered scorecard
+- Surfaces counts by severity (contradicted · unbacked · stale · bloat · hygiene · style) plus the gate verdict; **fails (exit 1) on contradicted / unbacked / stale claims**
+- site-theme is an **optional peer dependency** (a hard dep would pull astro into this zero-dep CLI). When it isn't installed, the gate **skips gracefully** (exit 0) — it never crashes the audit
 
 The gate says **what** must be true, not **how** to implement it. Applicability tags (`[all]`, `[npm]`, `[mcp]`, `[cli]`, `[desktop]`, `[vsix]`, `[container]`) prevent checkbox shame on repos where items don't apply.
 

--- a/bin/shipcheck.mjs
+++ b/bin/shipcheck.mjs
@@ -364,6 +364,163 @@ async function dogfoodCommand() {
   }
 }
 
+// --- Gate G: AI-native front door (delegates to @mcptoolshop/site-theme) ---
+//
+// Verifies that a repo's AI-native front door (README / AGENTS.md / llms.txt)
+// tells the truth, by consuming the `front-door` verifier shipped in
+// @mcptoolshop/site-theme (>=2.0.0). The verifier is read-only and makes no
+// network requests. site-theme is an OPTIONAL peer dependency — a hard dep
+// would drag astro/vite/sharp (~280 packages) into this zero-dep CLI — so when
+// it is not installed this gate SKIPS gracefully (exit 0) and never crashes the
+// audit. It is the machine-readable complement to the Operator Docs (C) and
+// Identity (E) gates.
+//
+// --- Standards compliance (memory/workflow_standards.md) ---
+// PIN_PER_STEP              2 — deterministic: same files in, same scorecard out.
+// ANDON_AUTHORITY          2 — exit 1 on any gate-failing finding; bad docs never ship.
+// NAMED_COMPENSATORS       n/a — read-only verify, no irreversible tool calls.
+// DECOMPOSE_BY_SECRETS     3 — own subcommand; the verifier engine lives in site-theme.
+// UNCERTAINTY_GATED_HUMANS 2 — a missing/unloadable dep SKIPS with a clear message, never asserts pass.
+// EXTERNAL_VERIFIER        3 — the verifier is a separate package (different codebase), not self-graded.
+
+const FRONT_DOOR_MODULE = "@mcptoolshop/site-theme/front-door";
+// Severity order mirrors site-theme's front-door model (risk-ordered, worst first).
+const FRONT_DOOR_SEVERITIES = ["contradicted", "unbacked", "stale", "bloat", "hygiene", "style"];
+// Severities that fail the gate (the front door makes a claim the repo does not back).
+const FRONT_DOOR_GATE_FAIL = new Set(["contradicted", "unbacked", "stale"]);
+
+// Map a front-door scorecard into shipcheck's dimension summary. Pure + defensive:
+// tolerates a partial/malformed scorecard so a verifier change can never crash the audit.
+function summarizeFrontDoor(scorecard) {
+  const findings = Array.isArray(scorecard?.findings) ? scorecard.findings : [];
+
+  const bySeverity = {};
+  for (const s of FRONT_DOOR_SEVERITIES) bySeverity[s] = 0;
+  const counts = scorecard?.counts?.bySeverity;
+  if (counts && typeof counts === "object") {
+    for (const s of FRONT_DOOR_SEVERITIES) bySeverity[s] = counts[s] ?? 0;
+  } else {
+    for (const f of findings) {
+      if (f && Object.prototype.hasOwnProperty.call(bySeverity, f.severity)) bySeverity[f.severity] += 1;
+    }
+  }
+
+  const topFindings = findings.filter((f) => f && FRONT_DOOR_GATE_FAIL.has(f.severity)).slice(0, 5);
+  const failing = scorecard?.gate?.failing ?? findings.filter((f) => f && FRONT_DOOR_GATE_FAIL.has(f.severity)).length;
+  const pass = scorecard?.gate ? scorecard.gate.pass === true : failing === 0;
+  const total = scorecard?.counts?.total ?? findings.length;
+  const reason =
+    scorecard?.gate?.reason ??
+    (pass
+      ? "No contradicted, unbacked, or stale claims."
+      : `${failing} gate-failing finding(s): the front door makes claims the repo does not back.`);
+
+  return { pass, failing, total, bySeverity, reason, topFindings };
+}
+
+// Run the front-door gate against `root`. `loadVerify` is injectable for tests;
+// it defaults to importing the optional site-theme peer. Never throws: any
+// failure to load or run the verifier becomes a graceful skip.
+async function runFrontDoorGate({ root = CWD, loadVerify } = {}) {
+  const load = loadVerify ?? (() => import(FRONT_DOOR_MODULE));
+
+  let mod;
+  try {
+    mod = await load();
+  } catch (err) {
+    return {
+      status: "skip",
+      reason: `${FRONT_DOOR_MODULE} not installed`,
+      detail: "Install @mcptoolshop/site-theme (>=2.0.0) to enable the AI-native front-door gate.",
+      error: err?.message || String(err),
+    };
+  }
+
+  const verify = mod?.verify;
+  if (typeof verify !== "function") {
+    return {
+      status: "skip",
+      reason: `${FRONT_DOOR_MODULE} did not export verify()`,
+      detail: "Upgrade @mcptoolshop/site-theme to >=2.0.0 — its front-door entry must export verify({ root }).",
+    };
+  }
+
+  let scorecard;
+  try {
+    scorecard = verify({ root });
+  } catch (err) {
+    return {
+      status: "skip",
+      reason: "front-door verify() threw",
+      detail: "The front-door verifier errored — audit continues without this gate.",
+      error: err?.message || String(err),
+    };
+  }
+
+  const summary = summarizeFrontDoor(scorecard);
+  return { status: summary.pass ? "pass" : "fail", summary };
+}
+
+function renderFrontDoorSeverityLine(bySeverity) {
+  return FRONT_DOOR_SEVERITIES.map((s) => `${s} ${bySeverity[s]}`).join(" · ");
+}
+
+function renderFrontDoorResult(result) {
+  if (result.status === "skip") {
+    log(`${DIM}${BOLD}Gate G: front door skipped${RESET}`);
+    log(`  ${DIM}○${RESET} ${result.reason}`);
+    if (result.detail) log(`  ${DIM}${result.detail}${RESET}`);
+    log("");
+    return;
+  }
+
+  const { summary } = result;
+  if (result.status === "pass") {
+    log(`${GREEN}${BOLD}Gate G: front door passed${RESET}`);
+    log(`  ${GREEN}✓${RESET} ${summary.reason}`);
+  } else {
+    log(`${RED}${BOLD}Gate G: front door failed${RESET}`);
+    log(`  ${RED}✗${RESET} ${summary.reason}`);
+  }
+  log(`  ${DIM}Severity: ${renderFrontDoorSeverityLine(summary.bySeverity)} (total ${summary.total})${RESET}`);
+  if (summary.topFindings.length > 0) {
+    log(`  ${YELLOW}${BOLD}Gate-failing findings:${RESET}`);
+    for (const f of summary.topFindings) {
+      const loc = f.line ? `${f.file}:${f.line}` : f.file;
+      log(`    ${RED}✗${RESET} [${f.severity}] ${f.title} ${DIM}(${loc})${RESET}`);
+    }
+  }
+  log("");
+}
+
+async function frontDoorCommand() {
+  log(`\n${BOLD}shipcheck front-door${RESET}\n`);
+
+  const args = process.argv.slice(3);
+  let root = CWD;
+  let json = false;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--root" && args[i + 1]) { root = resolve(CWD, args[++i]); }
+    else if (args[i] === "--json") { json = true; }
+  }
+
+  const result = await runFrontDoorGate({ root });
+
+  if (json) {
+    log(JSON.stringify(result));
+  } else {
+    renderFrontDoorResult(result);
+  }
+
+  if (result.status === "fail") {
+    if (process.env.SHIPCHECK_JSON && !json) {
+      console.error(JSON.stringify({ code: "FRONTDOOR_GATE_FAIL", message: result.summary.reason }));
+    }
+    process.exit(1);
+  }
+  // skip + pass exit 0 — a missing verifier never blocks the audit.
+}
+
 function helpCommand() {
   log(`
 ${BOLD}shipcheck${RESET} — product standards for MCP Tool Shop
@@ -372,6 +529,7 @@ ${BOLD}Usage:${RESET}
   npx @mcptoolshop/shipcheck init     Copy templates into current repo
   npx @mcptoolshop/shipcheck audit    Check SHIP_GATE.md progress
   npx @mcptoolshop/shipcheck dogfood  Check dogfood freshness (Gate F)
+  npx @mcptoolshop/shipcheck front-door  Verify the AI-native front door (Gate G)
   npx @mcptoolshop/shipcheck help     Show this message
   npx @mcptoolshop/shipcheck --version Show version
 
@@ -390,6 +548,13 @@ ${BOLD}What it does:${RESET}
            --freshness-days 30   Max age in days (default: 30)
            Exits 0 if accepted + pass + fresh, 1 otherwise
 
+  front-door  Verifies the AI-native front door (README / AGENTS.md / llms.txt)
+           via @mcptoolshop/site-theme's front-door verifier
+           --root <dir>          Repo to audit (default: cwd)
+           --json                Machine-readable result
+           Exits 1 on contradicted/unbacked/stale claims, 0 on pass
+           SKIPS gracefully (exit 0) when site-theme is not installed
+
 ${DIM}https://github.com/mcp-tool-shop-org/shipcheck${RESET}
 `);
 }
@@ -399,7 +564,7 @@ ${DIM}https://github.com/mcp-tool-shop-org/shipcheck${RESET}
 const command = process.argv[2] || "help";
 
 // Exports for testing
-export { evaluateDogfoodGate, fetchEnforcementMode };
+export { evaluateDogfoodGate, fetchEnforcementMode, summarizeFrontDoor, runFrontDoorGate };
 
 switch (command) {
   case "init":
@@ -410,6 +575,9 @@ switch (command) {
     break;
   case "dogfood":
     await dogfoodCommand();
+    break;
+  case "front-door":
+    await frontDoorCommand();
     break;
   case "--version":
   case "-V":

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,26 @@
 {
   "name": "@mcptoolshop/shipcheck",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcptoolshop/shipcheck",
-      "version": "1.0.0",
+      "version": "1.0.6",
       "license": "MIT",
       "bin": {
         "shipcheck": "bin/shipcheck.mjs"
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@mcptoolshop/site-theme": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@mcptoolshop/site-theme": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcptoolshop/shipcheck",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Product standards for MCP Tool Shop — Ship Gate checklist, error contract, and adoption guides.",
   "type": "module",
   "bin": {
@@ -37,5 +37,13 @@
   ],
   "engines": {
     "node": ">=18.0.0"
+  },
+  "peerDependencies": {
+    "@mcptoolshop/site-theme": ">=2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@mcptoolshop/site-theme": {
+      "optional": true
+    }
   }
 }

--- a/test/front-door.test.mjs
+++ b/test/front-door.test.mjs
@@ -1,0 +1,197 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { summarizeFrontDoor, runFrontDoorGate } from "../bin/shipcheck.mjs";
+
+const BIN = join(import.meta.dirname, "..", "bin", "shipcheck.mjs");
+
+function run(args, cwd, env = {}) {
+  try {
+    const stdout = execFileSync("node", [BIN, ...args], {
+      cwd,
+      encoding: "utf8",
+      env: { ...process.env, ...env },
+      timeout: 10_000,
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err) {
+    return { stdout: err.stdout || "", stderr: err.stderr || "", exitCode: err.status };
+  }
+}
+
+// A faithful shape of @mcptoolshop/site-theme/front-door's verify() scorecard.
+function scorecard({ findings = [], pass = true, failing = 0, reason } = {}) {
+  const bySeverity = { contradicted: 0, unbacked: 0, stale: 0, bloat: 0, hygiene: 0, style: 0 };
+  const byBucket = {};
+  for (const f of findings) {
+    bySeverity[f.severity] = (bySeverity[f.severity] ?? 0) + 1;
+    byBucket[f.bucket] = (byBucket[f.bucket] ?? 0) + 1;
+  }
+  return {
+    findings,
+    counts: { bySeverity, byBucket, total: findings.length },
+    gate: { pass, failing, reason: reason ?? (pass ? "No contradicted, unbacked, or stale claims." : `${failing} gate-failing finding(s).`) },
+  };
+}
+
+// --- summarizeFrontDoor (pure mapping) ---
+
+describe("summarizeFrontDoor", () => {
+  it("passes a clean scorecard with all-zero severity counts", () => {
+    const s = summarizeFrontDoor(scorecard({ pass: true }));
+    assert.equal(s.pass, true);
+    assert.equal(s.total, 0);
+    assert.equal(s.failing, 0);
+    assert.deepEqual(s.topFindings, []);
+    assert.equal(s.bySeverity.contradicted, 0);
+    assert.equal(s.bySeverity.style, 0);
+  });
+
+  it("fails and collects gate-failing findings", () => {
+    const findings = [
+      { severity: "contradicted", bucket: "contradicted", file: "README.md", line: 12, title: "Claims a flag that does not exist" },
+      { severity: "stale", bucket: "missing", file: "AGENTS.md", line: 3, title: "Links a missing script" },
+      { severity: "style", bucket: "unverifiable", file: "README.md", line: 40, title: "Long line" },
+    ];
+    const s = summarizeFrontDoor(scorecard({ findings, pass: false, failing: 2 }));
+    assert.equal(s.pass, false);
+    assert.equal(s.failing, 2);
+    assert.equal(s.total, 3);
+    // style is not a gate-failing severity
+    assert.equal(s.topFindings.length, 2);
+    assert.equal(s.bySeverity.contradicted, 1);
+    assert.equal(s.bySeverity.stale, 1);
+    assert.equal(s.bySeverity.style, 1);
+  });
+
+  it("caps top findings at 5", () => {
+    const findings = Array.from({ length: 9 }, (_, i) => ({
+      severity: "unbacked",
+      bucket: "missing",
+      file: "README.md",
+      line: i + 1,
+      title: `claim ${i}`,
+    }));
+    const s = summarizeFrontDoor(scorecard({ findings, pass: false, failing: 9 }));
+    assert.equal(s.topFindings.length, 5);
+    assert.equal(s.bySeverity.unbacked, 9);
+  });
+
+  it("derives counts when bySeverity is absent", () => {
+    const findings = [
+      { severity: "unbacked", file: "README.md", title: "x" },
+      { severity: "hygiene", file: "AGENTS.md", title: "y" },
+    ];
+    // No counts block — force the derive branch.
+    const s = summarizeFrontDoor({ findings, gate: { pass: false } });
+    assert.equal(s.pass, false);
+    assert.equal(s.bySeverity.unbacked, 1);
+    assert.equal(s.bySeverity.hygiene, 1);
+    assert.equal(s.failing, 1);
+  });
+
+  it("does not throw on a malformed/empty scorecard", () => {
+    for (const bad of [undefined, null, {}, { findings: "nope" }, { gate: null }]) {
+      const s = summarizeFrontDoor(bad);
+      assert.equal(typeof s.pass, "boolean");
+      assert.equal(typeof s.total, "number");
+      assert.ok(s.bySeverity && typeof s.bySeverity === "object");
+    }
+  });
+});
+
+// --- runFrontDoorGate (injected loader — no real dependency needed) ---
+
+describe("runFrontDoorGate", () => {
+  it("skips gracefully when the dependency cannot be resolved", async () => {
+    const result = await runFrontDoorGate({
+      root: "/tmp",
+      loadVerify: async () => { throw Object.assign(new Error("Cannot find module"), { code: "ERR_MODULE_NOT_FOUND" }); },
+    });
+    assert.equal(result.status, "skip");
+    assert.ok(/not installed/.test(result.reason));
+    assert.ok(result.detail.includes("@mcptoolshop/site-theme"));
+  });
+
+  it("skips when the module does not export verify()", async () => {
+    const result = await runFrontDoorGate({ root: "/tmp", loadVerify: async () => ({}) });
+    assert.equal(result.status, "skip");
+    assert.ok(/verify/.test(result.reason));
+  });
+
+  it("passes when verify() returns a passing scorecard", async () => {
+    const result = await runFrontDoorGate({
+      root: "/tmp",
+      loadVerify: async () => ({ verify: () => scorecard({ pass: true }) }),
+    });
+    assert.equal(result.status, "pass");
+    assert.equal(result.summary.pass, true);
+  });
+
+  it("fails when verify() returns a failing scorecard", async () => {
+    const findings = [{ severity: "contradicted", bucket: "contradicted", file: "README.md", line: 1, title: "lie" }];
+    const result = await runFrontDoorGate({
+      root: "/tmp",
+      loadVerify: async () => ({ verify: () => scorecard({ findings, pass: false, failing: 1 }) }),
+    });
+    assert.equal(result.status, "fail");
+    assert.equal(result.summary.failing, 1);
+    assert.equal(result.summary.topFindings.length, 1);
+  });
+
+  it("skips (never crashes) when verify() throws", async () => {
+    const result = await runFrontDoorGate({
+      root: "/tmp",
+      loadVerify: async () => ({ verify: () => { throw new Error("boom"); } }),
+    });
+    assert.equal(result.status, "skip");
+    assert.ok(/threw/.test(result.reason));
+    assert.equal(result.error, "boom");
+  });
+
+  it("passes root through to verify()", async () => {
+    let seen = null;
+    await runFrontDoorGate({
+      root: "/some/repo",
+      loadVerify: async () => ({ verify: (opts) => { seen = opts; return scorecard({ pass: true }); } }),
+    });
+    assert.deepEqual(seen, { root: "/some/repo" });
+  });
+});
+
+// --- front-door command (CLI E2E) ---
+//
+// site-theme is an optional peer dep and is not installed in the test env, so the
+// real CLI takes the graceful-skip path. Whether it skips (dep missing) or passes
+// (dep present + bare repo has only hygiene findings), the exit code is 0 — these
+// assertions stay true in both environments.
+
+describe("front-door command (CLI)", () => {
+  let tmp;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "shipcheck-fd-")); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("runs and exits 0 on a bare repo (skip or pass)", () => {
+    const { stdout, exitCode } = run(["front-door"], tmp);
+    assert.equal(exitCode, 0);
+    assert.ok(/front door/i.test(stdout), `expected front-door output, got: ${stdout}`);
+  });
+
+  it("emits valid JSON with --json", () => {
+    writeFileSync(join(tmp, "README.md"), "# Tmp\n\nA repo.\n");
+    const { stdout, exitCode } = run(["front-door", "--json"], tmp);
+    assert.equal(exitCode, 0);
+    const line = stdout.split("\n").find((l) => l.trim().startsWith("{"));
+    const parsed = JSON.parse(line);
+    assert.ok(["skip", "pass", "fail"].includes(parsed.status));
+  });
+
+  it("appears in help output", () => {
+    const { stdout, exitCode } = run(["help"], tmp);
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes("front-door"));
+  });
+});


### PR DESCRIPTION
## What

Adds **Gate G — the AI-native front-door gate** to shipcheck. It consumes the `front-door` verifier shipped in `@mcptoolshop/site-theme@>=2.0.0` and runs it as a first-class shipcheck gate via a new subcommand:

```bash
shipcheck front-door [--root <dir>] [--json]
```

It calls `verify({ root })`, maps the verifier's risk-ordered scorecard into a shipcheck dimension (the machine-readable complement to the Operator Docs **C** and Identity **E** gates), surfaces a counts-by-severity summary + gate verdict, and **exits 1 when `scorecard.gate.pass === false`** (contradicted / unbacked / stale claims).

## Design decisions

- **Optional peer dependency, not a hard dep.** Installing `@mcptoolshop/site-theme` as a regular dependency pulls **~280 packages** (astro, vite, sharp, tailwind…) into what is otherwise a zero-dependency CLI — and would expand the `npm audit` surface. It is declared as an **optional `peerDependency`** instead: the relationship + `>=2.0.0` floor are recorded, but the tree (and lockfile) stay clean. The verifier resolves at runtime in environments where site-theme is present (e.g. the full-treatment workspace).
- **Graceful skip, never crash.** If the verifier can't be resolved, doesn't export `verify()`, or throws, the gate emits a clear `Gate G: front door skipped` message and exits **0** — a missing verifier never blocks the audit. (Requirement: *"SKIP gracefully … never crash the audit."*)
- **Follows existing conventions.** Mirrors the Gate F (`dogfood`) pattern: own subcommand, pure exported helpers for unit testing, `--json` output, `SHIPCHECK_JSON` structured error on fail.
- The front-door `verify()` path is **read-only and makes no network requests**, consistent with shipcheck's trust model.

## Surfaced output

```
Gate G: front door failed
  ✗ 2 gate-failing finding(s): the front door makes claims the repo does not back.
  Severity: contradicted 1 · unbacked 0 · stale 1 · bloat 0 · hygiene 0 · style 1 (total 3)
  Gate-failing findings:
    ✗ [contradicted] Claims a flag that does not exist (README.md:12)
    ✗ [stale] Links a missing script (AGENTS.md:3)
```

## Tests

`test/front-door.test.mjs` — 14 new tests:
- `summarizeFrontDoor` — clean pass, fail + gate-failing collection, top-5 cap, count derivation, malformed-input tolerance
- `runFrontDoorGate` (injected loader, no real dep needed) — skip-on-unresolvable, skip-on-missing-export, pass, fail, skip-on-throw, root pass-through
- CLI E2E — exits 0 on a bare repo, valid `--json`, appears in `help`

Verified end-to-end against the **real** site-theme verifier (its own repo passes with 0 findings; shipcheck passes with 1 non-blocking hygiene finding).

## Verification (mirrors CI)

- `npm test` → 57 pass / 0 fail
- `npm run verify` → 100% pass rate
- `npm audit --audit-level=moderate` → 0 vulnerabilities
- `npm pack --dry-run` → clean, `1.0.6`

## Version

`1.0.5 → 1.0.6` (patch bump per shipcheck product standards), CHANGELOG updated.

> Please review — do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
